### PR TITLE
  Fix existing service registration by removing random UUID suffix from service name

### DIFF
--- a/native/src/main/java/io/ballerina/wso2/apim/catalog/ServiceCatalog.java
+++ b/native/src/main/java/io/ballerina/wso2/apim/catalog/ServiceCatalog.java
@@ -38,8 +38,6 @@ import io.swagger.v3.oas.models.OpenAPI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
-import java.util.UUID;
 
 import static io.ballerina.wso2.apim.catalog.utils.Constants.BALLERINA;
 import static io.ballerina.wso2.apim.catalog.utils.Constants.CONTROL_PLANE_PACKAGE_NAME;
@@ -181,10 +179,8 @@ public final class ServiceCatalog {
     }
 
     private static void updateServiceName(BMap<BString, Object> artifactValues, HttpServiceConfig httpServiceConfig) {
-        String uniqueSuffix = UUID.randomUUID().toString().replace("-", "").
-                substring(0, 10).toUpperCase(Locale.ROOT); // To temporarily resolve service name uniqueness conflicts
         artifactValues.put(StringUtils.fromString(NAME),
-                StringUtils.fromString(httpServiceConfig.basePath + uniqueSuffix));
+                StringUtils.fromString(httpServiceConfig.basePath));
     }
 
     private static void updateServiceUrl(BMap<BString, Object> artifactValues, HttpServiceConfig httpServiceConfig) {

--- a/test-resources/sample_project_0/Dependencies.toml
+++ b/test-resources/sample_project_0/Dependencies.toml
@@ -253,7 +253,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},

--- a/test-resources/sample_project_1/Dependencies.toml
+++ b/test-resources/sample_project_1/Dependencies.toml
@@ -287,7 +287,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -364,7 +364,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},

--- a/test-resources/sample_project_10/Dependencies.toml
+++ b/test-resources/sample_project_10/Dependencies.toml
@@ -253,7 +253,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},

--- a/test-resources/sample_project_11/Dependencies.toml
+++ b/test-resources/sample_project_11/Dependencies.toml
@@ -253,7 +253,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},

--- a/test-resources/sample_project_2/Dependencies.toml
+++ b/test-resources/sample_project_2/Dependencies.toml
@@ -253,7 +253,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},

--- a/test-resources/sample_project_3/Dependencies.toml
+++ b/test-resources/sample_project_3/Dependencies.toml
@@ -253,7 +253,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},

--- a/test-resources/sample_project_4/Dependencies.toml
+++ b/test-resources/sample_project_4/Dependencies.toml
@@ -253,7 +253,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},

--- a/test-resources/sample_project_5/Dependencies.toml
+++ b/test-resources/sample_project_5/Dependencies.toml
@@ -254,7 +254,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -262,7 +262,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "openapi"
-version = "2.4.0"
+version = "2.4.1"
 modules = [
 	{org = "ballerina", packageName = "openapi", moduleName = "openapi"}
 ]
@@ -316,7 +316,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},

--- a/test-resources/sample_project_6/Dependencies.toml
+++ b/test-resources/sample_project_6/Dependencies.toml
@@ -253,7 +253,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},

--- a/test-resources/sample_project_7/Dependencies.toml
+++ b/test-resources/sample_project_7/Dependencies.toml
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -360,7 +360,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},

--- a/test-resources/sample_project_8/Dependencies.toml
+++ b/test-resources/sample_project_8/Dependencies.toml
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -311,7 +311,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},

--- a/test-resources/sample_project_9/Dependencies.toml
+++ b/test-resources/sample_project_9/Dependencies.toml
@@ -253,7 +253,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},


### PR DESCRIPTION
## Purpose

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This pull request fixes the service registration logic to use the basePath directly as the service name, removing a randomly-generated UUID suffix that was previously appended to service names.

## Key Changes

**Functional Change:**
- Updated the `ServiceCatalog.java` service name assignment to use the basePath directly instead of appending a UUID-based suffix, simplifying the service identification mechanism and improving consistency in service naming

**Administrative Changes:**
- Bumped the module version from 1.2.2 to 1.2.3 across the codebase
- Updated the `ballerina:observe` dependency from 1.7.0 to 1.7.1
- Updated native JAR artifact references to use the new SNAPSHOT versions (1.2.3-SNAPSHOT)
- Updated all test resource project dependencies to reflect the new versions
- Added package keywords metadata to the main Ballerina module configuration

## Impact
The change streamlines service registration by removing unnecessary UUID generation, resulting in cleaner service names based on the basePath and more predictable service identification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->