### PR TITLE
Upgrade jackson-core to 2.18.6 to fix DoS vulnerability 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ ballerinaGradlePluginVersion=2.3.0
 swaggerParserVersion=2.1.16
 swaggerVersion=2.2.10
 snakeYamlversion=2.0
-fasterxmlJacksonCoreVersion=2.15.2
+fasterxmlJacksonCoreVersion=2.18.6
 commonsVersion=2.15.1
 
 stdlibIoVersion=1.8.0


### PR DESCRIPTION
## Purpose

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates the `jackson-core` dependency to version 2.18.6 by modifying the `fasterxmlJacksonCoreVersion` property in `gradle.properties`, upgrading from version 2.15.2. The change is intended to improve application security and stability.

## Changes

- **gradle.properties**: Updated `fasterxmlJacksonCoreVersion` from `2.15.2` to `2.18.6`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->