### PR TITLE
Fix `NullPointerException` caused by `MAIN` artifact type

### DIFF
--- a/native/src/main/java/io/ballerina/wso2/apim/catalog/ServiceCatalog.java
+++ b/native/src/main/java/io/ballerina/wso2/apim/catalog/ServiceCatalog.java
@@ -88,6 +88,9 @@ public final class ServiceCatalog {
         BArray arrayValue = ValueCreator.createArrayValue(arrayType);
 
         for (Artifact artifact : env.getRepository().getArtifacts()) {
+            if (artifact.type != Artifact.ArtifactType.SERVICE) {
+                continue;
+            }
             Object serviceObj = artifact.getDetail(Constants.SERVICE);
             Type originalType = ((BObject) serviceObj).getOriginalType();
             Module module = originalType.getPackage();


### PR DESCRIPTION
## Description
It resolves: https://github.com/ballerina-platform/ballerina-library/issues/8735

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR improves stability by preventing a null reference when iterating repository artifacts. ServiceCatalog.getArtifacts() now skips non-service artifacts early (only processes ArtifactType.SERVICE), avoiding attempts to read service details from artifacts that don't carry them. This prevents the NullPointerException seen when non-service artifacts (e.g., MAIN) were processed and allows the listener to start successfully.

Files modified
- native/src/main/java/io/ballerina/wso2/apim/catalog/ServiceCatalog.java (+3/-0)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->