### PR TITLE
Provide configurable `registeredServiceBaseUrl`

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.3"
+version = "1.2.5"
 keywords = ["Type/Connector", "Type/Trigger", "Vendor/WSO2", "Area/Developer Tools"]
 distribution = "2201.13.1"
 
@@ -11,8 +11,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina"
 artifactId = "wso2.apim.catalog-native"
-version = "1.2.3"
-path = "../native/build/libs/wso2.apim.catalog-native-1.2.3-SNAPSHOT.jar"
+version = "1.2.5"
+path = "../native/build/libs/wso2.apim.catalog-native-1.2.5-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.4"
+version = "1.3.0"
 keywords = ["Type/Connector", "Type/Trigger", "Vendor/WSO2", "Area/Developer Tools"]
 distribution = "2201.13.1"
 
@@ -11,8 +11,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina"
 artifactId = "wso2.apim.catalog-native"
-version = "1.2.4"
-path = "../native/build/libs/wso2.apim.catalog-native-1.2.4-SNAPSHOT.jar"
+version = "1.3.0"
+path = "../native/build/libs/wso2.apim.catalog-native-1.3.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,8 @@
 [package]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.2"
+version = "1.2.3"
+keywords = ["Type/Connector", "Type/Trigger", "Vendor/WSO2", "Area/Developer Tools"]
 distribution = "2201.13.1"
 
 [platform.java21]
@@ -10,38 +11,38 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina"
 artifactId = "wso2.apim.catalog-native"
-version = "1.2.2"
-path = "../native/build/libs/wso2.apim.catalog-native-1.2.2.jar"
+version = "1.2.3"
+path = "../native/build/libs/wso2.apim.catalog-native-1.2.3-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-core"
-version = "2.15.2"
-path = "lib/jackson-core-2.15.2.jar"
+version = "2.18.6"
+path = "lib/jackson-core-2.18.6.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-databind"
-version = "2.15.2"
-path = "lib/jackson-databind-2.15.2.jar"
+version = "2.18.6"
+path = "lib/jackson-databind-2.18.6.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-annotations"
-version = "2.15.2"
-path = "lib/jackson-annotations-2.15.2.jar"
+version = "2.18.6"
+path = "lib/jackson-annotations-2.18.6.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.datatype"
 artifactId = "jackson-datatype-jsr310"
-version = "2.15.2"
-path = "lib/jackson-datatype-jsr310-2.15.2.jar"
+version = "2.18.6"
+path = "lib/jackson-datatype-jsr310-2.18.6.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.dataformat"
 artifactId = "jackson-dataformat-yaml"
-version = "2.15.2"
-path = "lib/jackson-dataformat-yaml-2.15.2.jar"
+version = "2.18.6"
+path = "lib/jackson-dataformat-yaml-2.18.6.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.swagger.core.v3"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.5"
+version = "1.2.4"
 keywords = ["Type/Connector", "Type/Trigger", "Vendor/WSO2", "Area/Developer Tools"]
 distribution = "2201.13.1"
 
@@ -11,8 +11,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina"
 artifactId = "wso2.apim.catalog-native"
-version = "1.2.5"
-path = "../native/build/libs/wso2.apim.catalog-native-1.2.5-SNAPSHOT.jar"
+version = "1.2.4"
+path = "../native/build/libs/wso2.apim.catalog-native-1.2.4-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "wso2.apim.catalog-compiler-plugin"
 class = "io.ballerina.wso2.apim.catalog.ServiceCatalogCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/wso2.apim.catalog-compiler-plugin-1.2.3-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/wso2.apim.catalog-compiler-plugin-1.2.5-SNAPSHOT.jar"
 
 [[dependency]]
 path = "lib/ballerina-to-openapi-2.4.0.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "wso2.apim.catalog-compiler-plugin"
 class = "io.ballerina.wso2.apim.catalog.ServiceCatalogCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/wso2.apim.catalog-compiler-plugin-1.2.5-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/wso2.apim.catalog-compiler-plugin-1.2.4-SNAPSHOT.jar"
 
 [[dependency]]
 path = "lib/ballerina-to-openapi-2.4.0.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "wso2.apim.catalog-compiler-plugin"
 class = "io.ballerina.wso2.apim.catalog.ServiceCatalogCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/wso2.apim.catalog-compiler-plugin-1.2.2.jar"
+path = "../compiler-plugin/build/libs/wso2.apim.catalog-compiler-plugin-1.2.3-SNAPSHOT.jar"
 
 [[dependency]]
 path = "lib/ballerina-to-openapi-2.4.0.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "wso2.apim.catalog-compiler-plugin"
 class = "io.ballerina.wso2.apim.catalog.ServiceCatalogCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/wso2.apim.catalog-compiler-plugin-1.2.4-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/wso2.apim.catalog-compiler-plugin-1.3.0-SNAPSHOT.jar"
 
 [[dependency]]
 path = "lib/ballerina-to-openapi-2.4.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -73,7 +73,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.15.5"
+version = "2.15.4"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -106,7 +106,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -253,7 +253,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -280,7 +280,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.1"
+version = "2.8.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -73,7 +73,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.15.4"
+version = "2.15.5"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -310,7 +310,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.3"
+version = "1.2.5"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -310,7 +310,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.5"
+version = "1.2.4"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -106,7 +106,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -253,7 +253,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -280,7 +280,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -310,7 +310,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -310,7 +310,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "wso2.apim.catalog"
-version = "1.2.4"
+version = "1.3.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},

--- a/ballerina/service.bal
+++ b/ballerina/service.bal
@@ -29,18 +29,19 @@ configurable string? clientSecureSocketpath = ();
 configurable string clientSecureSocketpassword = "";
 configurable string? serverCert = ();
 configurable string[] scopes = ["service_catalog:service_view", "apim:api_view", "service_catalog:service_write"];
-# External base URL applied to every service registered in the APIM Service
-# Catalog, replacing the auto-derived `http://localhost:<port>`. Use this when
-# all services are reachable through the same load balancer or ingress.
-# Overridden per-service by `registeredServiceBaseUrls`.
-configurable string? registeredServiceHostUrl = ();
-# Per-listener external base URL map, keyed by `"host:port"`
-# (e.g. `"localhost:9090"`). All services attached to that listener are
-# registered using the mapped base URL. Takes precedence over
-# `registeredServiceBaseUrl` for matching listeners. Use this when individual
-# listeners are reachable through different load balancers or external hosts.
-# Same format rules as `registeredServiceBaseUrl` apply to each value.
-configurable map<string> registeredServiceHostUrls = {};
+# Controls the serviceUrl registered in the APIM Service Catalog.
+# Accepts either a single string or a map of strings:
+#
+# - `string`: one base URL applied to every service
+#   (e.g. `registeredServiceHostUrl = "http://my-alb.example.com"`)
+#
+# - `map<string>`: per-listener base URLs, keyed by `"host:port"`
+#   (e.g. `"localhost:9090" = "http://alb-a.example.com"`).
+#   All services on that listener are registered under the mapped base URL.
+#
+# Each value must be an absolute URL with scheme and host (optional port).
+# No trailing slash. No path component.
+configurable string|map<string>|() registeredServiceHostUrl = ();
 
 listener Listener 'listener = new Listener(port);
 
@@ -100,21 +101,23 @@ function publishOrUpdateService(ServiceArtifact artifact) returns Service|error 
     string serviceIdentifier = slashPos is int
         ? withoutScheme.substring(0, slashPos)
         : withoutScheme;
-    // Ballerina's TOML parser includes surrounding double-quotes as literal
-    // characters in map keys when the Config.toml key was a quoted string.
-    // Normalise each key by stripping those quotes before comparing.
-    string? perServiceBase = ();
-    foreach [string, string] [k, v] in registeredServiceHostUrls.entries() {
-        string normalizedKey = (k.length() > 1 && k.startsWith("\"") && k.endsWith("\""))
-            ? k.substring(1, k.length() - 1)
-            : k;
-        if normalizedKey == serviceIdentifier {
-            perServiceBase = v;
-            break;
+    string? effectiveBase = ();
+    string|map<string>|() hostUrlConfig = registeredServiceHostUrl;
+    if hostUrlConfig is string {
+        effectiveBase = hostUrlConfig;
+    } else if hostUrlConfig is map<string> {
+        // Ballerina's TOML parser includes surrounding double-quotes as literal
+        // characters in map keys for quoted TOML keys. Normalise before comparing.
+        foreach [string, string] [k, v] in hostUrlConfig.entries() {
+            string normalizedKey = (k.length() > 1 && k.startsWith("\"") && k.endsWith("\""))
+                ? k.substring(1, k.length() - 1)
+                : k;
+            if normalizedKey == serviceIdentifier {
+                effectiveBase = v;
+                break;
+            }
         }
     }
-    // Per-service map takes precedence; fall back to the global single value.
-    string? effectiveBase = perServiceBase ?: registeredServiceHostUrl;
     if effectiveBase is string && effectiveBase.length() > 0 {
         string base = effectiveBase.endsWith("/")
             ? effectiveBase.substring(0, effectiveBase.length() - 1)

--- a/ballerina/service.bal
+++ b/ballerina/service.bal
@@ -94,9 +94,12 @@ function publishOrUpdateService(ServiceArtifact artifact) returns Service|error 
     string resolvedServiceUrl = artifact.serviceUrl;
     // Derive "host:port" listener key from the auto-derived serviceUrl
     // ("http://host:port/basePath"): strip scheme then take up to the first "/".
-    string withoutScheme = artifact.serviceUrl.startsWith("http://")
-        ? artifact.serviceUrl.substring(7)
-        : artifact.serviceUrl;
+    string withoutScheme = artifact.serviceUrl;
+    if withoutScheme.startsWith("https://") {
+        withoutScheme = withoutScheme.substring(8);
+    } else if withoutScheme.startsWith("http://") {
+        withoutScheme = withoutScheme.substring(7);
+    }
     int? slashPos = withoutScheme.indexOf("/");
     string serviceIdentifier = slashPos is int
         ? withoutScheme.substring(0, slashPos)

--- a/ballerina/service.bal
+++ b/ballerina/service.bal
@@ -29,6 +29,7 @@ configurable string? clientSecureSocketpath = ();
 configurable string clientSecureSocketpassword = "";
 configurable string? serverCert = ();
 configurable string[] scopes = ["service_catalog:service_view", "apim:api_view", "service_catalog:service_write"];
+configurable string? registeredServiceBaseUrl = ();
 
 listener Listener 'listener = new Listener(port);
 
@@ -78,18 +79,21 @@ function getServiceIdByKey(string serviceKey) returns string|error|() {
 
 function publishOrUpdateService(ServiceArtifact artifact) returns Service|error {
     string|() serviceId = check getServiceIdByKey(artifact.serviceKey);
+    string resolvedServiceUrl = registeredServiceBaseUrl is string
+        ? string `${<string>registeredServiceBaseUrl}${artifact.name}`
+        : artifact.serviceUrl;
     if serviceId is () {
-            return apimClient->/services.post({
+        return apimClient->/services.post({
             serviceMetadata: {
                 name: artifact.name,
                 description: artifact.description,
                 'version: artifact.version,
                 serviceKey: artifact.serviceKey,
-                serviceUrl: artifact.serviceUrl,
+                serviceUrl: resolvedServiceUrl,
                 definitionType: artifact.definitionType,
                 securityType: artifact.securityType,
                 mutualSSLEnabled: artifact.mutualSSLEnabled,
-                definitionUrl: artifact.definitionUrl
+                definitionUrl: resolvedServiceUrl
             },
             inlineContent: artifact.definitionFileContent
         });
@@ -100,11 +104,11 @@ function publishOrUpdateService(ServiceArtifact artifact) returns Service|error 
             description: artifact.description,
             'version: artifact.version,
             serviceKey: artifact.serviceKey,
-            serviceUrl: artifact.serviceUrl,
+            serviceUrl: resolvedServiceUrl,
             definitionType: artifact.definitionType,
             securityType: artifact.securityType,
             mutualSSLEnabled: artifact.mutualSSLEnabled,
-            definitionUrl: artifact.definitionUrl
+            definitionUrl: resolvedServiceUrl
         },
         inlineContent: artifact.definitionFileContent
     });

--- a/ballerina/service.bal
+++ b/ballerina/service.bal
@@ -29,6 +29,11 @@ configurable string? clientSecureSocketpath = ();
 configurable string clientSecureSocketpassword = "";
 configurable string? serverCert = ();
 configurable string[] scopes = ["service_catalog:service_view", "apim:api_view", "service_catalog:service_write"];
+# External base URL registered with WSO2 APIM Service Catalog in place of the
+# auto-derived `http://localhost:<port>`. Must be an absolute URL containing the
+# scheme and host with an optional port
+# (e.g. `http://my-alb.example.com` or `https://ingress.example.com:8443`).
+# No trailing slash. No path component.
 configurable string? registeredServiceBaseUrl = ();
 
 listener Listener 'listener = new Listener(port);
@@ -79,9 +84,14 @@ function getServiceIdByKey(string serviceKey) returns string|error|() {
 
 function publishOrUpdateService(ServiceArtifact artifact) returns Service|error {
     string|() serviceId = check getServiceIdByKey(artifact.serviceKey);
-    string resolvedServiceUrl = registeredServiceBaseUrl is string
-        ? string `${<string>registeredServiceBaseUrl}${artifact.name}`
-        : artifact.serviceUrl;
+    string resolvedServiceUrl = artifact.serviceUrl;
+    string? baseUrlConfig = registeredServiceBaseUrl;
+    if baseUrlConfig is string && baseUrlConfig.length() > 0 {
+        string base = baseUrlConfig.endsWith("/")
+            ? baseUrlConfig.substring(0, baseUrlConfig.length() - 1)
+            : baseUrlConfig;
+        resolvedServiceUrl = base + artifact.name;
+    }
     if serviceId is () {
         return apimClient->/services.post({
             serviceMetadata: {

--- a/ballerina/service.bal
+++ b/ballerina/service.bal
@@ -29,12 +29,18 @@ configurable string? clientSecureSocketpath = ();
 configurable string clientSecureSocketpassword = "";
 configurable string? serverCert = ();
 configurable string[] scopes = ["service_catalog:service_view", "apim:api_view", "service_catalog:service_write"];
-# External base URL registered with WSO2 APIM Service Catalog in place of the
-# auto-derived `http://localhost:<port>`. Must be an absolute URL containing the
-# scheme and host with an optional port
-# (e.g. `http://my-alb.example.com` or `https://ingress.example.com:8443`).
-# No trailing slash. No path component.
+# External base URL applied to every service registered in the APIM Service
+# Catalog, replacing the auto-derived `http://localhost:<port>`. Use this when
+# all services are reachable through the same load balancer or ingress.
+# Overridden per-service by `registeredServiceBaseUrls`.
 configurable string? registeredServiceBaseUrl = ();
+# Per-listener external base URL map, keyed by `"host:port"`
+# (e.g. `"localhost:9090"`). All services attached to that listener are
+# registered using the mapped base URL. Takes precedence over
+# `registeredServiceBaseUrl` for matching listeners. Use this when individual
+# listeners are reachable through different load balancers or external hosts.
+# Same format rules as `registeredServiceBaseUrl` apply to each value.
+configurable map<string> registeredServiceBaseUrls = {};
 
 listener Listener 'listener = new Listener(port);
 
@@ -85,11 +91,34 @@ function getServiceIdByKey(string serviceKey) returns string|error|() {
 function publishOrUpdateService(ServiceArtifact artifact) returns Service|error {
     string|() serviceId = check getServiceIdByKey(artifact.serviceKey);
     string resolvedServiceUrl = artifact.serviceUrl;
-    string? baseUrlConfig = registeredServiceBaseUrl;
-    if baseUrlConfig is string && baseUrlConfig.length() > 0 {
-        string base = baseUrlConfig.endsWith("/")
-            ? baseUrlConfig.substring(0, baseUrlConfig.length() - 1)
-            : baseUrlConfig;
+    // Derive "host:port" listener key from the auto-derived serviceUrl
+    // ("http://host:port/basePath"): strip scheme then take up to the first "/".
+    string withoutScheme = artifact.serviceUrl.startsWith("http://")
+        ? artifact.serviceUrl.substring(7)
+        : artifact.serviceUrl;
+    int? slashPos = withoutScheme.indexOf("/");
+    string serviceIdentifier = slashPos is int
+        ? withoutScheme.substring(0, slashPos)
+        : withoutScheme;
+    // Ballerina's TOML parser includes surrounding double-quotes as literal
+    // characters in map keys when the Config.toml key was a quoted string.
+    // Normalise each key by stripping those quotes before comparing.
+    string? perServiceBase = ();
+    foreach [string, string] [k, v] in registeredServiceBaseUrls.entries() {
+        string normalizedKey = (k.length() > 1 && k.startsWith("\"") && k.endsWith("\""))
+            ? k.substring(1, k.length() - 1)
+            : k;
+        if normalizedKey == serviceIdentifier {
+            perServiceBase = v;
+            break;
+        }
+    }
+    // Per-service map takes precedence; fall back to the global single value.
+    string? effectiveBase = perServiceBase ?: registeredServiceBaseUrl;
+    if effectiveBase is string && effectiveBase.length() > 0 {
+        string base = effectiveBase.endsWith("/")
+            ? effectiveBase.substring(0, effectiveBase.length() - 1)
+            : effectiveBase;
         resolvedServiceUrl = base + artifact.name;
     }
     if serviceId is () {

--- a/ballerina/service.bal
+++ b/ballerina/service.bal
@@ -119,7 +119,7 @@ function publishOrUpdateService(ServiceArtifact artifact) returns Service|error 
         string base = effectiveBase.endsWith("/")
             ? effectiveBase.substring(0, effectiveBase.length() - 1)
             : effectiveBase;
-        resolvedServiceUrl = base + artifact.name;
+        resolvedServiceUrl = artifact.name.startsWith("/") ? base + artifact.name : base + "/" + artifact.name;
     }
     if serviceId is () {
         return apimClient->/services.post({

--- a/ballerina/service.bal
+++ b/ballerina/service.bal
@@ -33,14 +33,14 @@ configurable string[] scopes = ["service_catalog:service_view", "apim:api_view",
 # Catalog, replacing the auto-derived `http://localhost:<port>`. Use this when
 # all services are reachable through the same load balancer or ingress.
 # Overridden per-service by `registeredServiceBaseUrls`.
-configurable string? registeredServiceBaseUrl = ();
+configurable string? registeredServiceHostUrl = ();
 # Per-listener external base URL map, keyed by `"host:port"`
 # (e.g. `"localhost:9090"`). All services attached to that listener are
 # registered using the mapped base URL. Takes precedence over
 # `registeredServiceBaseUrl` for matching listeners. Use this when individual
 # listeners are reachable through different load balancers or external hosts.
 # Same format rules as `registeredServiceBaseUrl` apply to each value.
-configurable map<string> registeredServiceBaseUrls = {};
+configurable map<string> registeredServiceHostUrls = {};
 
 listener Listener 'listener = new Listener(port);
 
@@ -104,7 +104,7 @@ function publishOrUpdateService(ServiceArtifact artifact) returns Service|error 
     // characters in map keys when the Config.toml key was a quoted string.
     // Normalise each key by stripping those quotes before comparing.
     string? perServiceBase = ();
-    foreach [string, string] [k, v] in registeredServiceBaseUrls.entries() {
+    foreach [string, string] [k, v] in registeredServiceHostUrls.entries() {
         string normalizedKey = (k.length() > 1 && k.startsWith("\"") && k.endsWith("\""))
             ? k.substring(1, k.length() - 1)
             : k;
@@ -114,7 +114,7 @@ function publishOrUpdateService(ServiceArtifact artifact) returns Service|error 
         }
     }
     // Per-service map takes precedence; fall back to the global single value.
-    string? effectiveBase = perServiceBase ?: registeredServiceBaseUrl;
+    string? effectiveBase = perServiceBase ?: registeredServiceHostUrl;
     if effectiveBase is string && effectiveBase.length() > 0 {
         string base = effectiveBase.endsWith("/")
             ? effectiveBase.substring(0, effectiveBase.length() - 1)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.ballerina.wso2.apim.catalog
-version=1.2.3-SNAPSHOT
+version=1.3.0-SNAPSHOT
 
 ballerinaLangVersion=2201.13.1
 


### PR DESCRIPTION
## Purpose
`registeredServiceHostUrl` configurable needed to support cloud deployments behind load balancers in the `ballerinax/wso2.apim.catalog` module.

In cloud deployments where a Ballerina service runs behind a load balancer (AWS ALB/NLB, Azure Load Balancer, Kubernetes Ingress, etc.), the `wso2.apim.catalog module registers an incorrect backend serviceUrl in the APIM Service Catalog.
The module derives the backend URL by reading host from @http:ServiceConfig. In cloud environments, this field either:

Is omitted (defaults to b7a.default → resolves to localhost), causing APIM to call localhost on itself — always unreachable
Is set to the external hostname (e.g., the ALB DNS name) to fix catalog registration, but then Ballerina's HTTP dispatcher enforces virtual host matching against that value, causing it to reject incoming requests whose Host: header doesn't match — breaking the service itself
The two concerns — virtual host binding (Ballerina HTTP runtime) and backend URL registration (APIM catalog) — are conflated into a single field that cannot satisfy both simultaneously in any non-local deployment.


Fixes https://github.com/wso2-enterprise/wso2-integration-internal/issues/4872

## Examples
There are two scenarios that we can apply a custom registered service host url.

- Scenario 1: One registered service base url for all listeners

Users can configure one registered service host url for all listeners attached to the Ballerina application.

```toml
[ballerinax.wso2.apim.catalog]
serviceUrl    = "https://localhost:9444/api/am/service-catalog/v1"
tokenUrl      = "https://localhost:9444/oauth2/token"
username      = "admin"
password      = "admin"
clientId      = "..."
clientSecret  = "..."
registeredServiceHostUrl = "http://my-load-balancer.example.com"            
```

- Scenario 2: Multiple registered service base url for each listener

Users can configure multiple registered service host urls for each listener as a map. 

```toml
[ballerinax.wso2.apim.catalog]
serviceUrl    = "https://localhost:9444/api/am/service-catalog/v1"
tokenUrl      = "https://localhost:9444/oauth2/token"
username      = "admin"
password      = "admin"
clientId      = "..."
clientSecret  = "..."

[ballerinax.wso2.apim.catalog.registeredServiceHostUrl]
"localhost:9091" = "http://alb-a.example.com"
"localhost:9092" = "http://alb-b.example.com"
```

Following is an example how the service url registered in APIM.
```
service `/orders1` on listener `localhost:9091`
service `/orders2` on listener `localhost:9092`
service `/orders3` on listener `localhost:9092`
```

<img width="907" height="735" alt="Image" src="https://github.com/user-attachments/assets/adbb99ce-a468-455f-8c78-7dfa674d1896" />

<img width="913" height="730" alt="Image" src="https://github.com/user-attachments/assets/f0221539-9ce6-48ca-8146-d56b605d51e2" />

<img width="1818" height="1465" alt="Image" src="https://github.com/user-attachments/assets/ced3292c-0064-4d63-8c5b-22bab3233439" />



## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- New configuration: introduces a configurable registeredServiceHostUrl (accepts a single URL or a map keyed by "host:port") to control the base URL used when registering backend services in the APIM catalog. This lets deployments behind load balancers provide the external service URL independently of Ballerina's virtual host binding.

- Registration behavior: registration now computes a normalized registered service URL (derives a host:port identifier from the artifact, supports TOML-quoted map keys, trims trailing slashes, and concatenates base + artifact name with a single separator). The resolved URL is used for serviceMetadata.serviceUrl and serviceMetadata.definitionUrl when creating or updating catalog entries, decoupling catalog registration from the HTTP listener virtual host.

- Builds and versioning: module and build artifacts bumped to 1.3.0 / 1.3.0-SNAPSHOT; gradle/ballerina metadata updated accordingly.

- Dependency updates: upgrades Jackson libraries and related native/compiler-plugin artifact references to the newer 1.3.0-SNAPSHOT artifacts.

- Minor: small alignment/indentation cleanups in service registration code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->